### PR TITLE
fix: stuck after default scene

### DIFF
--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -207,7 +207,7 @@ sequence:
                             (start_3 > end_3 and (now >= start_3 or now < end_3)) %} {# over midnight #}
         {% set default_scene = default_scene_1 if in_range_1 else (default_scene_2 if in_range_2 else (default_scene_3 if in_range_3 else "")) %}
         
-        {% set on_and_off_scenes = on_scenes + [off_scene] %}
+        {% set on_and_off_scenes = [default_scene] + on_scenes + [off_scene] %}
         {% set all_scenes = on_scenes + [off_scene, default_scene_1, default_scene_2, default_scene_3] %}
         {% set all_scenes_sorted = (expand(all_scenes) | rejectattr('state','equalto','unknown') | sort(attribute='state', reverse=true)) %}
         {% set last_scene = ((all_scenes_sorted | length) > 0 and all_scenes_sorted[0].entity_id) or off_scene %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -58,7 +58,7 @@ blueprint:
     **Help & FAQ**: [Scene Toggle with Off State](https://community.home-assistant.io/t/scene-toggle-on-off-rotate-different-on-scenes/879839)
 
 
-    **Version**: 1.1
+    **Version**: 1.2
 
 
     If you like my work and support feel free to support me.


### PR DESCRIPTION
The last change introduced a bug, that after the default scene switching to the next scenes didn't work until the reset time was elapsed. This fixes it.