### PR TITLE
feat: new on detection

### DIFF
--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -191,12 +191,12 @@ variables:
           or now()
         )
     }}
+  is_reset: "{{ (as_timestamp(now()) - last_triggered) >= reset_time }}"
 sequence:
   - service: scene.turn_on
     data_template:
       transition: !input transition
       entity_id: >
-        {% set is_reset = (as_timestamp(now()) - last_triggered) >= reset_time %}
 
         {% set now = now().strftime('%H:%M:%S') %}
         {% set in_range_1 = (start_1 <= end_1 and start_1 <= now < end_1) or
@@ -206,7 +206,7 @@ sequence:
         {% set in_range_3 = (start_3 <= end_3 and start_3 <= now < end_3) or
                             (start_3 > end_3 and (now >= start_3 or now < end_3)) %} {# over midnight #}
         {% set default_scene = default_scene_1 if in_range_1 else (default_scene_2 if in_range_2 else (default_scene_3 if in_range_3 else "")) %}
-        
+
         {% set on_and_off_scenes = [default_scene] + on_scenes + [off_scene] %}
         {% set all_scenes = on_scenes + [off_scene, default_scene_1, default_scene_2, default_scene_3] %}
         {% set all_scenes_sorted = (expand(all_scenes) | rejectattr('state','equalto','unknown') | sort(attribute='state', reverse=true)) %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -7,52 +7,44 @@ blueprint:
 
     You can toggle your lights (and other devices) with this script on and off. For
     the on state, scenes are used. With multiple executions (before the reset time)
-    this script will rotate through your scenes in the given order. The last on scene
+    this script will rotate through your scenes in the given order. The last activated scene
     will be remembered. A default scene can be set for turning on after a reset.
 
     ## Examples
 
     ### Without default scene
 
-    Selected scenes: "ambiente", "medium", "bright"
-    Default scene: -
+    ```mermaid
+    graph LR;
+        Off1-->Scene1a;
+        Scene1a-->Scene2a;
+        Scene2a--after some time-->Off2;
+        Off2--after some time-->Scene2b;
 
-    Sequence:
-
-    - everything is off in the beginning
-
-    - script executed -> scene "ambiente"
-
-    - script executed again -> scene "medium"
-
-    - a while later (longer than the reset time)
-
-    - script executed -> turn everything off
-
-    - a while later (longer than the reset time)
-
-    - script executed -> scene "medium"
+        Off1[Off]
+        Off2[Off]
+        Scene1a[Scene 1]
+        Scene2a[Scene 2]
+        Scene2b[Scene 2]
+    ```
 
     ### With default scene
 
-    Selected scenes: "ambiente", "medium", "bright"
-    Default scene: "medium"
+    ```mermaid
+    graph LR;
+        Off1-->Defaulta;
+        Defaulta-->Scene1a;
+        Scene1a-->Scene2a;
+        Scene2a--after some time-->Off2;
+        Off2--after some time-->Defaultb;
 
-    Sequence:
-
-    - everything is off in the beginning
-
-    - script executed -> scene "medium"
-
-    - script executed again -> scene "bright"
-
-    - a while later (longer than the reset time)
-
-    - script executed -> turn everything off
-
-    - a while later (longer than the reset time)
-
-    - script executed -> scene "medium"
+        Off1[Off]
+        Off2[Off]
+        Defaulta[Default]
+        Defaultb[Default]
+        Scene1a[Scene 1]
+        Scene2a[Scene 2]
+    ```
 
 
     **Help & FAQ**: [Scene Toggle with Off State](https://community.home-assistant.io/t/scene-toggle-on-off-rotate-different-on-scenes/879839)
@@ -68,9 +60,9 @@ blueprint:
   source_url: https://github.com/jona96/homeassistant/blob/main/blueprints/script/scene_toggle_with_off_state.yaml
   domain: script
   input:
-    on_scenes:
-      name: On Scenes
-      description: Scenes for on state (used for cycling).
+    scenes:
+      name: Scenes
+      description: "Scenes used for cycling"
       default: []
       selector:
         entity:
@@ -79,7 +71,7 @@ blueprint:
           multiple: true
     default_scene_1:
       name: "Default 1: Scene"
-      description: "Optional scene to activate beween 'Default 1: Start Time' and 'Default 1: End Time' when turning on after the reset time. If empty, the last used 'on scene' is reactivated."
+      description: "Optional scene to activate beween 'Default 1: Start Time' and 'Default 1: End Time' when turning on after the reset time. If empty, the last used scene is reactivated."
       default: ""
       selector:
         entity:
@@ -100,7 +92,7 @@ blueprint:
         time:
     default_scene_2:
       name: "Default 2: Scene"
-      description: "Optional scene to activate beween 'Default 2: Start Time' and 'Default 2: End Time' when turning on after the reset time. If empty, the last used 'on scene' is reactivated."
+      description: "Optional scene to activate beween 'Default 2: Start Time' and 'Default 2: End Time' when turning on after the reset time. If empty, the last used scene is reactivated."
       default: ""
       selector:
         entity:
@@ -121,7 +113,7 @@ blueprint:
         time:
     default_scene_3:
       name: "Default 3: Scene"
-      description: "Optional scene to activate beween 'Default 3: Start Time' and 'Default 3: End Time' when turning on after the reset time. If empty, the last used 'on scene' is reactivated."
+      description: "Optional scene to activate beween 'Default 3: Start Time' and 'Default 3: End Time' when turning on after the reset time. If empty, the last used scene is reactivated."
       default: ""
       selector:
         entity:
@@ -164,7 +156,7 @@ blueprint:
           mode: slider
 mode: queued
 variables:
-  on_scenes: !input on_scenes
+  scenes: !input scenes
   start_1: !input default_start_time_1
   end_1: !input default_end_time_1
   default_scene_1: !input default_scene_1
@@ -199,9 +191,9 @@ variables:
     }}
   all_scenes: >
     {% if default_scene == "" %}
-      {{ on_scenes }}
+      {{ scenes }}
     {% else %}
-      {{ [default_scene] + on_scenes }}
+      {{ [default_scene] + scenes }}
     {% endif %}
   all_entities: >
     {% set entities = namespace(list=[]) %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -211,54 +211,42 @@ variables:
       (default_scene_2 if is_now_in_range(start_2, end_2) else 
       (default_scene_3 if is_now_in_range(start_3, end_3) else ""))
     }}
-  on_scenes_new: >
+  all_scenes: >
     {% if default_scene == "" %}
       {{ on_scenes }}
     {% else %}
       {{ [default_scene] + on_scenes }}
     {% endif %}
-  should_turn_off: >
-    {% set is_on = namespace(any=false) %}
-    {% for scene in on_scenes_new %}
+  all_entities: >
+    {% set entities = namespace(list=[]) %}
+    {% for scene in all_scenes %}
       {% if scene != None %}
         {% set scene_entities = state_attr(scene, 'entity_id') %}
         {% if scene_entities != None %}
-          {% for entity in scene_entities %}
-            {% if states(entity) == 'on' %}
-              {% set is_on.any = true %}
-            {% endif %}
-          {% endfor %}
+          {% set entities.list = entities.list + scene_entities %}
         {% endif %}
+      {% endif %}
+    {% endfor %}
+    {{ entities.list | unique | list }}
+  should_turn_off: >
+    {% set is_on = namespace(any=false) %}
+    {% for entity in all_entities %}
+      {% if states(entity) == 'on' %}
+        {% set is_on.any = true %}
       {% endif %}
     {% endfor %}
     {{ is_on.any }}
 sequence:
-  - service: scene.turn_on
-    data_template:
-      transition: !input transition
-      entity_id: >
-        {% set on_and_off_scenes = [default_scene] + on_scenes + [off_scene] %}
-        {% set all_scenes = on_scenes + [off_scene, default_scene_1, default_scene_2, default_scene_3] %}
-        {% set all_scenes_sorted = (expand(all_scenes) | rejectattr('state','equalto','unknown') | sort(attribute='state', reverse=true)) %}
-        {% set last_scene = ((all_scenes_sorted | length) > 0 and all_scenes_sorted[0].entity_id) or off_scene %}
-        {% set on_scenes_sorted = (expand(on_scenes) | rejectattr('state','equalto','unknown') | sort(attribute='state', reverse=true)) %}
-        {% set last_on_scene = ((on_scenes_sorted | length) > 0 and on_scenes_sorted[0].entity_id) or on_scenes[0] %}
-        {% set is_on = (last_scene != off_scene) %}
-
-        {% if is_reset %}
-          {# toggle between off ↔ last on scene #}
-          {% if is_on %}
-            {{ off_scene }}
-          {% else %}
-            {% if default_scene != "" %}
-              {{ default_scene }}
-            {% else %}
-              {{ last_on_scene }}
-            {% endif %}
-          {% endif %}
-        {% else %}
-          {# switch to next scene (including off scene) #}
-          {% set index = on_and_off_scenes.index(last_scene) %}
-          {% set next_index = (index + 1) % (on_and_off_scenes | count) %}
-          {{ on_and_off_scenes[next_index] }}
-        {% endif %}
+  # turn off
+  - choose:
+    - conditions: >
+        {{ should_turn_off }}
+      sequence:
+        - action: light.turn_off
+          target:
+            entity_id: "{{ all_entities }}"
+    # turn on/switch scene
+    default:
+      - action: light.turn_on
+        target:
+          entity_id: "{{ all_entities }}"

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -198,13 +198,13 @@ sequence:
       transition: !input transition
       entity_id: >
 
-        {% set now = now().strftime('%H:%M:%S') %}
-        {% set in_range_1 = (start_1 <= end_1 and start_1 <= now < end_1) or
-                            (start_1 > end_1 and (now >= start_1 or now < end_1)) %} {# over midnight #}
-        {% set in_range_2 = (start_2 <= end_2 and start_2 <= now < end_2) or
-                            (start_2 > end_2 and (now >= start_2 or now < end_2)) %} {# over midnight #}
-        {% set in_range_3 = (start_3 <= end_3 and start_3 <= now < end_3) or
-                            (start_3 > end_3 and (now >= start_3 or now < end_3)) %} {# over midnight #}
+        {% set now_ = now().strftime('%H:%M:%S') %}
+        {% set in_range_1 = (start_1 <= end_1 and start_1 <= now_ < end_1) or
+                            (start_1 > end_1 and (now_ >= start_1 or now_ < end_1)) %} {# over midnight #}
+        {% set in_range_2 = (start_2 <= end_2 and start_2 <= now_ < end_2) or
+                            (start_2 > end_2 and (now_ >= start_2 or now_ < end_2)) %} {# over midnight #}
+        {% set in_range_3 = (start_3 <= end_3 and start_3 <= now_ < end_3) or
+                            (start_3 > end_3 and (now_ >= start_3 or now_ < end_3)) %} {# over midnight #}
         {% set default_scene = default_scene_1 if in_range_1 else (default_scene_2 if in_range_2 else (default_scene_3 if in_range_3 else "")) %}
 
         {% set on_and_off_scenes = [default_scene] + on_scenes + [off_scene] %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -185,13 +185,9 @@ variables:
   end_3: !input default_end_time_3
   default_scene_3: !input default_scene_3
   reset_time: !input reset_time
-  last_triggered: >
-    {{ as_timestamp(
-        state_attr(this.entity_id,'last_triggered')
-          or now()
-        )
-    }}
-  is_reset: "{{ (as_timestamp(now()) - last_triggered) >= reset_time }}"
+  is_reset: >
+    {% set last_triggered = as_timestamp(state_attr(this.entity_id,'last_triggered') or now()) %}
+    {{ (as_timestamp(now()) - last_triggered) >= reset_time }}
   default_scene: >
     {% macro is_now_in_range(start, end) %}
       {% set now_ = now().strftime('%H:%M:%S') %}
@@ -207,8 +203,8 @@ variables:
       {% endif %}
     {% endmacro %}
     {{
-      default_scene_1 if is_now_in_range(start_1, end_1) else 
-      (default_scene_2 if is_now_in_range(start_2, end_2) else 
+      default_scene_1 if is_now_in_range(start_1, end_1) else
+      (default_scene_2 if is_now_in_range(start_2, end_2) else
       (default_scene_3 if is_now_in_range(start_3, end_3) else ""))
     }}
   all_scenes: >
@@ -228,7 +224,7 @@ variables:
       {% endif %}
     {% endfor %}
     {{ entities.list | unique | list }}
-  should_turn_off: >
+  is_on: >
     {% set is_on = namespace(any=false) %}
     {% for entity in all_entities %}
       {% if states(entity) == 'on' %}
@@ -236,19 +232,38 @@ variables:
       {% endif %}
     {% endfor %}
     {{ is_on.any }}
+  last_scene: >
+    {% set all_scenes_sorted = (expand(all_scenes) | rejectattr('state','equalto','unknown') | sort(attribute='state', reverse=true)) %}
+    {{ ((all_scenes_sorted | length) > 0 and all_scenes_sorted[0].entity_id) or all_scenes[0] }}
 sequence:
-  # turn off
+  # past reset time: toggle between off ↔ last on scene
   - choose:
     - conditions: >
-        {{ should_turn_off }}
+        {{ is_reset }}
       sequence:
-        - action: light.turn_off
-          target:
-            entity_id: "{{ all_entities }}"
-    # turn on/switch scene
+        - choose:
+          - conditions: >
+              {{ is_on }}
+            sequence:
+              # turn off
+              - action: light.turn_off
+                target:
+                  entity_id: "{{ all_entities }}"
+                data:
+                  transition: !input transition
+          default:
+            # turn on default scene or last scene
+            - action: scene.turn_on
+              data_template:
+                transition: !input transition
+                entity_id: >
+                  {{ default_scene or last_scene }}
     default:
+      # switch to next scene
       - action: scene.turn_on
         data_template:
           transition: !input transition
           entity_id: >
-            {{ all_scenes[0] }}
+            {% set index = all_scenes.index(last_scene) %}
+            {% set next_index = (index + 1) % (all_scenes | count) %}
+            {{ all_scenes[next_index] }}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -247,6 +247,8 @@ sequence:
             entity_id: "{{ all_entities }}"
     # turn on/switch scene
     default:
-      - action: light.turn_on
-        target:
-          entity_id: "{{ all_entities }}"
+      - action: scene.turn_on
+        data_template:
+          transition: !input transition
+          entity_id: >
+            {{ all_scenes[0] }}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -198,14 +198,24 @@ sequence:
       transition: !input transition
       entity_id: >
 
-        {% set now_ = now().strftime('%H:%M:%S') %}
-        {% set in_range_1 = (start_1 <= end_1 and start_1 <= now_ < end_1) or
-                            (start_1 > end_1 and (now_ >= start_1 or now_ < end_1)) %} {# over midnight #}
-        {% set in_range_2 = (start_2 <= end_2 and start_2 <= now_ < end_2) or
-                            (start_2 > end_2 and (now_ >= start_2 or now_ < end_2)) %} {# over midnight #}
-        {% set in_range_3 = (start_3 <= end_3 and start_3 <= now_ < end_3) or
-                            (start_3 > end_3 and (now_ >= start_3 or now_ < end_3)) %} {# over midnight #}
-        {% set default_scene = default_scene_1 if in_range_1 else (default_scene_2 if in_range_2 else (default_scene_3 if in_range_3 else "")) %}
+        {% macro is_now_in_range(start, end) %}
+          {% set now_ = now().strftime('%H:%M:%S') %}
+          {% if start == "" or end == "" %}
+            {{ false }}
+          {% else %}
+            {% if start <= end %}
+              {{ start <= now_ < end }}
+            {% else %}
+              {# time range spans midnight #}
+              {{ now_ >= start or now_ < end }}
+            {% endif %}
+          {% endif %}
+        {% endmacro %}
+
+        {% set default_scene = default_scene_1 if is_now_in_range(start_1, end_1) else 
+              (default_scene_2 if is_now_in_range(start_2, end_2) else 
+              (default_scene_3 if is_now_in_range(start_3, end_3) else "")) 
+        %}
 
         {% set on_and_off_scenes = [default_scene] + on_scenes + [off_scene] %}
         {% set all_scenes = on_scenes + [off_scene, default_scene_1, default_scene_2, default_scene_3] %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -193,7 +193,7 @@ variables:
     {% if default_scene == "" %}
       {{ scenes }}
     {% else %}
-      {{ [default_scene] + scenes }}
+      {{ [default_scene] + scenes | unique | list }}
     {% endif %}
   all_entities: >
     {% set entities = namespace(list=[]) %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -192,31 +192,30 @@ variables:
         )
     }}
   is_reset: "{{ (as_timestamp(now()) - last_triggered) >= reset_time }}"
+  default_scene: >
+    {% macro is_now_in_range(start, end) %}
+      {% set now_ = now().strftime('%H:%M:%S') %}
+      {% if start == "" or end == "" %}
+        {{ false }}
+      {% else %}
+        {% if start <= end %}
+          {{ start <= now_ < end }}
+        {% else %}
+          {# time range spans midnight #}
+          {{ now_ >= start or now_ < end }}
+        {% endif %}
+      {% endif %}
+    {% endmacro %}
+    {% set default_scene = default_scene_1 if is_now_in_range(start_1, end_1) else 
+          (default_scene_2 if is_now_in_range(start_2, end_2) else 
+          (default_scene_3 if is_now_in_range(start_3, end_3) else "")) 
+    %}
+    {{ default_scene }}
 sequence:
   - service: scene.turn_on
     data_template:
       transition: !input transition
       entity_id: >
-
-        {% macro is_now_in_range(start, end) %}
-          {% set now_ = now().strftime('%H:%M:%S') %}
-          {% if start == "" or end == "" %}
-            {{ false }}
-          {% else %}
-            {% if start <= end %}
-              {{ start <= now_ < end }}
-            {% else %}
-              {# time range spans midnight #}
-              {{ now_ >= start or now_ < end }}
-            {% endif %}
-          {% endif %}
-        {% endmacro %}
-
-        {% set default_scene = default_scene_1 if is_now_in_range(start_1, end_1) else 
-              (default_scene_2 if is_now_in_range(start_2, end_2) else 
-              (default_scene_3 if is_now_in_range(start_3, end_3) else "")) 
-        %}
-
         {% set on_and_off_scenes = [default_scene] + on_scenes + [off_scene] %}
         {% set all_scenes = on_scenes + [off_scene, default_scene_1, default_scene_2, default_scene_3] %}
         {% set all_scenes_sorted = (expand(all_scenes) | rejectattr('state','equalto','unknown') | sort(attribute='state', reverse=true)) %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -211,6 +211,12 @@ variables:
       (default_scene_2 if is_now_in_range(start_2, end_2) else 
       (default_scene_3 if is_now_in_range(start_3, end_3) else ""))
     }}
+  on_scenes_new: >
+    {% if default_scene == "" %}
+      {{ on_scenes }}
+    {% else %}
+      {{ [default_scene] + on_scenes }}
+    {% endif %}
 sequence:
   - service: scene.turn_on
     data_template:

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -77,15 +77,6 @@ blueprint:
           filter:
             - domain: scene
           multiple: true
-    off_scene:
-      name: Off Scene
-      description: Scene for the off state.
-      default: ""
-      selector:
-        entity:
-          filter:
-            - domain: scene
-          multiple: false
     default_scene_1:
       name: "Default 1: Scene"
       description: "Optional scene to activate beween 'Default 1: Start Time' and 'Default 1: End Time' when turning on after the reset time. If empty, the last used 'on scene' is reactivated."
@@ -174,7 +165,6 @@ blueprint:
 mode: queued
 variables:
   on_scenes: !input on_scenes
-  off_scene: !input off_scene
   start_1: !input default_start_time_1
   end_1: !input default_end_time_1
   default_scene_1: !input default_scene_1

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -259,11 +259,17 @@ sequence:
                 entity_id: >
                   {{ default_scene or last_scene }}
     default:
-      # switch to next scene
+      # switch to next scene or first scene directly after off
       - action: scene.turn_on
         data_template:
           transition: !input transition
           entity_id: >
-            {% set index = all_scenes.index(last_scene) %}
-            {% set next_index = (index + 1) % (all_scenes | count) %}
-            {{ all_scenes[next_index] }}
+            {% if is_on %}
+              {# next scene #}
+              {% set index = all_scenes.index(last_scene) %}
+              {% set next_index = (index + 1) % (all_scenes | count) %}
+              {{ all_scenes[next_index] }}
+            {% else %}
+              {# first scene #}
+              {{ all_scenes[0] }}
+            {% endif %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -12,39 +12,13 @@ blueprint:
 
     ## Examples
 
-    ### Without default scene
+    Without default scene:
 
-    ```mermaid
-    graph LR;
-        Off1-->Scene1a;
-        Scene1a-->Scene2a;
-        Scene2a--after some time-->Off2;
-        Off2--after some time-->Scene2b;
+    Off -> Scene 1 -> Scene 2 -(after a while)-> Off -(after a while)-> Scene 2
 
-        Off1[Off]
-        Off2[Off]
-        Scene1a[Scene 1]
-        Scene2a[Scene 2]
-        Scene2b[Scene 2]
-    ```
-
-    ### With default scene
-
-    ```mermaid
-    graph LR;
-        Off1-->Defaulta;
-        Defaulta-->Scene1a;
-        Scene1a-->Scene2a;
-        Scene2a--after some time-->Off2;
-        Off2--after some time-->Defaultb;
-
-        Off1[Off]
-        Off2[Off]
-        Defaulta[Default]
-        Defaultb[Default]
-        Scene1a[Scene 1]
-        Scene2a[Scene 2]
-    ```
+    With default scene:
+    
+    Off -> Default -> Scene 1 -> Scene 2 -(after a while)-> Off -(after a while)-> Default
 
 
     **Help & FAQ**: [Scene Toggle with Off State](https://community.home-assistant.io/t/scene-toggle-on-off-rotate-different-on-scenes/879839)

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -189,23 +189,23 @@ variables:
     {% set last_triggered = as_timestamp(state_attr(this.entity_id,'last_triggered') or now()) %}
     {{ (as_timestamp(now()) - last_triggered) >= reset_time }}
   default_scene: >
-    {% macro is_now_in_range(start, end) %}
-      {% set now_ = now().strftime('%H:%M:%S') %}
-      {% if start == "" or end == "" %}
-        {{ false }}
-      {% else %}
-        {% if start <= end %}
-          {{ start <= now_ < end }}
-        {% else %}
+    {%- macro is_now_in_range(start, end) -%}
+      {%- set now_ = now().strftime('%H:%M:%S') -%}
+      {%- if start == "" or end == "" -%}
+        {{- false -}}
+      {%- else -%}
+        {%- if start <= end -%}
+          {{- start <= now_ < end -}}
+        {%- else -%}
           {# time range spans midnight #}
-          {{ now_ >= start or now_ < end }}
-        {% endif %}
-      {% endif %}
-    {% endmacro %}
+          {{- now_ >= start or now_ < end -}}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endmacro -%}
     {{
-      default_scene_1 if is_now_in_range(start_1, end_1) else
-      (default_scene_2 if is_now_in_range(start_2, end_2) else
-      (default_scene_3 if is_now_in_range(start_3, end_3) else ""))
+      default_scene_1 if is_now_in_range(start_1, end_1) == 'True' else
+      (default_scene_2 if is_now_in_range(start_2, end_2) == 'True' else
+      (default_scene_3 if is_now_in_range(start_3, end_3) == 'True' else ""))
     }}
   all_scenes: >
     {% if default_scene == "" %}

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -206,11 +206,11 @@ variables:
         {% endif %}
       {% endif %}
     {% endmacro %}
-    {% set default_scene = default_scene_1 if is_now_in_range(start_1, end_1) else 
-          (default_scene_2 if is_now_in_range(start_2, end_2) else 
-          (default_scene_3 if is_now_in_range(start_3, end_3) else "")) 
-    %}
-    {{ default_scene }}
+    {{
+      default_scene_1 if is_now_in_range(start_1, end_1) else 
+      (default_scene_2 if is_now_in_range(start_2, end_2) else 
+      (default_scene_3 if is_now_in_range(start_3, end_3) else ""))
+    }}
 sequence:
   - service: scene.turn_on
     data_template:

--- a/blueprints/script/scene_toggle_with_off_state.yaml
+++ b/blueprints/script/scene_toggle_with_off_state.yaml
@@ -217,6 +217,21 @@ variables:
     {% else %}
       {{ [default_scene] + on_scenes }}
     {% endif %}
+  should_turn_off: >
+    {% set is_on = namespace(any=false) %}
+    {% for scene in on_scenes_new %}
+      {% if scene != None %}
+        {% set scene_entities = state_attr(scene, 'entity_id') %}
+        {% if scene_entities != None %}
+          {% for entity in scene_entities %}
+            {% if states(entity) == 'on' %}
+              {% set is_on.any = true %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+    {{ is_on.any }}
 sequence:
   - service: scene.turn_on
     data_template:


### PR DESCRIPTION
Rewrite most of the script to avoid the off scene.
Instead all entities from all scenes are evaluated / switched off.

Changed behavior:
- no off state within the reset time - only cycle between (on) scenes

This also fixes a few bugs.
